### PR TITLE
Add git ignore file for pycache and node modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+pycache
+__pycache__/
+node_modules


### PR DESCRIPTION
## Type of Change

[x] Configuration / .gitignore Changes

## Context

This pull request aims to add a .gitignore file to the repository in order to exclude generated files, particularly the "__pycache__" directory and "node_modules" directory, from version control.

This is necessary to make sure the repo stays clean 

## Changes Made

- Added a `.gitignore` file to the repository.
- Included patterns to ignore the "__pycache__" directory.
- Included patterns to ignore the "node_modules" directory.

## Screenshots

[Insert any relevant screenshots, if applicable]

## Checklist

- [x] I have tested these changes locally
- [ ] I have updated the documentation, if applicable (NA)
- [ ] I have added unit tests, if applicable (NA)
